### PR TITLE
Add downloads bookmark

### DIFF
--- a/src/components/HomeDownloadSection.vue
+++ b/src/components/HomeDownloadSection.vue
@@ -1,5 +1,6 @@
 <template>
   <div class="download home-section">
+    <a id="download">Pobieranie wersji rozwojowych</a>
     <h2 class="title">Pobieranie</h2>
     <home-download-version-switcher v-if="$mq === 'md'" :activeSection="activeSection" />
     <h3 class="section-name section-name-beta" v-if="$mq === 'lg'">BETA</h3>
@@ -42,6 +43,10 @@
 </script>
 
 <style lang="scss" scoped>
+  #download {
+    visibility: hidden;
+  }
+
   .download {
     height: 100vh;
     box-sizing: border-box;


### PR DESCRIPTION
There's a link with `#download` anchor in the [README file](https://github.com/wulkanowy/wulkanowy/blob/develop/README.md) of wulkanowy/wulkanowy repository, but there are no `download` bookmark in Wulkanowy's website, so I decided to add it by myself. Is it ok?